### PR TITLE
updated url to work with both dev and prod

### DIFF
--- a/frontend/services/apiClient.ts
+++ b/frontend/services/apiClient.ts
@@ -1,23 +1,25 @@
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 
-const { manifest } = Constants;
+// const { manifest } = Constants;
 
 // Determine base URL based on platform
-const BASE_URL = (() => {
+// const BASE_URL = (() => {
 
-  const publicAPI = "https://api.amesafterdark.com/api";
+//   const publicAPI = "https://api.amesafterdark.com/api";
 
-  if (Platform.OS === "web") {
-      return publicAPI;
-  } else if (Platform.OS === "android") {
-    // Android emulator routes host machine via 10.0.2.2
-      return publicAPI;
-  } else {
-    // iOS simulator or physical device
-      return publicAPI;
-  }
-})();
+//   if (Platform.OS === "web") {
+//       return publicAPI;
+//   } else if (Platform.OS === "android") {
+//     // Android emulator routes host machine via 10.0.2.2
+//       return publicAPI;
+//   } else {
+//     // iOS simulator or physical device
+//       return publicAPI;
+//   }
+// })();
+
+const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
 
 export async function apiFetch(endpoint: string, options: RequestInit = {}) {
   try {


### PR DESCRIPTION
For this to work, everyone will need to add two files to their frontend folder: 

1.  `.env.development`
2. `.env.production`

**Note:** I will put the files in Teams, but it is just the URL for prod and dev; using the env files just prevents exposing it to the frontend

When running it with Expo, the command specifies which `.env` file to use.

1. `npx expo start --dev-client`: this will use the development
2. `npx expo start --no-dev`: this will use the production