### PR TITLE
Resizing Integration

### DIFF
--- a/frontend/app/(app)/(tabs)/bars/[id].tsx
+++ b/frontend/app/(app)/(tabs)/bars/[id].tsx
@@ -7,7 +7,7 @@ import { fetchLocationById, MapLocation } from "@/services/locationService";
 import { getNow, isActive, isBarOpen } from "@/utils/schedule";
 import { Theme } from '@/constants/theme';
 import ErrorState from "@/components/ui/error-state";
-import { getLatestWeekAlbums, Album } from "@/services/galleryService";
+import { getLatestWeekAlbums, Album, getResizedImageUri } from "@/services/galleryService";
 
 import {
   BarHeader,
@@ -34,6 +34,7 @@ export default function BarProfile() {
   const toggleGalleryOverlay = () => setIsGalleryVisible(!isGalleryVisible);
   const [latestGalleryImage, setLatestGalleryImage] = useState<string | null>(null);
   const [specificAlbum, setSpecificAlbum] = useState<Album | null>(null);
+  const [isGalleryLoading, setIsGalleryLoading] = useState(true);
 
   const navigateToGallery = () => {
     setIsGalleryVisible(false);
@@ -53,22 +54,27 @@ export default function BarProfile() {
 
   useEffect(() => {
     const fetchLatestGalleryImage = async () => {
+      setIsGalleryLoading(true);
       try {
         const albums = await getLatestWeekAlbums();
 
         if (albums && albums.length > 0) {
-          const nameMap: Record<string, string> = {
-            "Cy's Roost": "Cy's",
-            "Outlaws": "Outlaw's",
-            "Sips": "Sip's",
-            "Paddy's Irish Pub": "Paddy's"
+          const nameMap: Record<string, string[]> = {
+            "Cy's Roost": ["Cy's"],
+            "Outlaws": ["Outlaw's", "Outlaws"],
+            "Sips": ["Sip's"],
+            "Paddy's Irish Pub": ["Paddy's"]
           };
-          const searchName = nameMap[bar?.name || ""] || bar?.name;
-          const matchingAlbum = albums.find(a => a.barName === searchName);
+          const searchName = nameMap[bar?.name || ""];
+          const matchingAlbum = albums.find(a => searchName?.includes(a.barName));
 
           if (matchingAlbum) {
             setSpecificAlbum(matchingAlbum);
-            setLatestGalleryImage(matchingAlbum.coverUrl);
+
+            const optimizedModalCover = matchingAlbum.coverUrl ? 
+              getResizedImageUri(matchingAlbum.coverUrl, 800) : null;
+            
+            setLatestGalleryImage(optimizedModalCover);
           } else {
             setSpecificAlbum(null);
             setLatestGalleryImage(null);
@@ -76,6 +82,8 @@ export default function BarProfile() {
         }
       } catch (err) {
         console.log("Could not fetch latest gallery image, falling back to bar cover.");
+      } finally {
+        setIsGalleryLoading(false);
       }
     };
 
@@ -242,6 +250,7 @@ export default function BarProfile() {
         barName={bar?.name}
         latestImage={latestGalleryImage}
         hasSpecificAlbum={!!specificAlbum}
+        isLoading={isGalleryLoading}
       />
     </>
   );

--- a/frontend/app/(app)/(tabs)/gallery/index.tsx
+++ b/frontend/app/(app)/(tabs)/gallery/index.tsx
@@ -10,7 +10,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { shouldForceErrorPage } from "@/utils/dev-error-pages";
 import ErrorState from "@/components/ui/error-state";
 import { Theme } from "@/constants/theme";
-import { getLatestWeekAlbums } from "@/services/galleryService";
+import { getLatestWeekAlbums, getResizedImageUri } from "@/services/galleryService";
 import GalleryFallback from "./Galleryfallback";
 import { useTopHeaderVisibility } from '@/context/top-header-visibility';
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -260,7 +260,8 @@ export default function GalleryScreen() {
                     }
                   >
                     {album.coverUrl ? (
-                      <Image source={{ uri: album.coverUrl }} style={styles.albumImage} contentFit="cover" transition={200} cachePolicy={"memory-disk"} />
+                      <Image source={{ uri: getResizedImageUri(album.coverUrl, 600) }} 
+                        style={styles.albumImage} contentFit="cover" transition={200} cachePolicy={"memory-disk"} />
                     ) : (
                       <View style={styles.placeholderCover} />
                     )}

--- a/frontend/components/bars/bar-detail-components.tsx
+++ b/frontend/components/bars/bar-detail-components.tsx
@@ -33,6 +33,7 @@ interface BarGalleryModalProps {
   barName?: string;
   latestImage?: string | null;
   hasSpecificAlbum?: boolean;
+  isLoading?: boolean;
 }
 
 export const BarMapModal = ({ visible, onClose, onOpenInMaps, onOpenInAppleMaps, mapData, barName }: BarMapModalProps) => (
@@ -100,7 +101,7 @@ export const BarMapModal = ({ visible, onClose, onOpenInMaps, onOpenInAppleMaps,
   </Modal>
 );
 
-export const BarGalleryModal = ({ visible, onClose, onOpenGallery, assets, barName, latestImage, hasSpecificAlbum }: BarGalleryModalProps) => (
+export const BarGalleryModal = ({ visible, onClose, onOpenGallery, assets, barName, latestImage, hasSpecificAlbum, isLoading  }: BarGalleryModalProps) => (
   <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
     <TouchableWithoutFeedback onPress={onClose}>
       <View style={styles.modalOverlay}>
@@ -110,25 +111,36 @@ export const BarGalleryModal = ({ visible, onClose, onOpenGallery, assets, barNa
               <FontAwesome name="close" size={16} color="white" />
             </TouchableOpacity>
 
-            <Image source={latestImage ? { uri: latestImage } : assets?.cover} style={styles.galleryPreviewImage} />
-
-            <View style={styles.overlayFooter}>
-              <Text style={styles.galleryModalTitle}>
-                {hasSpecificAlbum ? `${barName}'s Gallery` : "Ames After Dark Gallery"}
-              </Text>
-              <Text style={styles.galleryModalText}>
-                {hasSpecificAlbum
-                  ? `Check out the latest photos from ${barName}! Tap below to explore the full album.`
-                  : `Dive into the city's nightlife gallery. Check out the latest photos from around town!`}
-              </Text>
-
-              <View style={styles.primaryActionsRow}>
-                <TouchableOpacity style={styles.openInMapsBtn} onPress={onOpenGallery}>
-                  <FontAwesome name="image" size={18} color="white" style={{ marginRight: 8 }} />
-                  <Text style={styles.openInMapsText}>Enter Gallery</Text>
-                </TouchableOpacity>
+            {isLoading ? (
+              <View style={styles.loadingContainer}>
+                <ActivityIndicator size="large" color={Theme.dark.primary} />
+                <Text style={styles.loadingText}>Checking for recent photos...</Text>
               </View>
-            </View>
+            ) : (
+              <>
+              <Image source={latestImage ? { uri: latestImage } : assets?.cover} style={styles.galleryPreviewImage} />
+
+              <View style={styles.overlayFooter}>
+                <Text style={styles.galleryModalTitle}>
+                  {hasSpecificAlbum ? `${barName}'s Gallery` : "Ames After Dark Gallery"}
+                </Text>
+                <Text style={styles.galleryModalText}>
+                  {hasSpecificAlbum
+                    ? `Check out the latest photos from ${barName}! Tap below to explore the full album.`
+                    : `Dive into the city's nightlife gallery. Check out the latest photos from around town!`}
+                </Text>
+
+                <View style={styles.primaryActionsRow}>
+                  <TouchableOpacity style={styles.openInMapsBtn} onPress={onOpenGallery}>
+                    <FontAwesome name="image" size={18} color="white" style={{ marginRight: 8 }} />
+                    <Text style={styles.openInMapsText}>Enter Gallery</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </>
+            )}
+
+            
 
           </View>
         </TouchableWithoutFeedback>

--- a/frontend/services/galleryService.ts
+++ b/frontend/services/galleryService.ts
@@ -86,8 +86,9 @@ export async function getLatestWeekAlbums(): Promise<Album[]> {
       }
     }
   });
-  // Strip parsedDate and return clean array of standard Albums
-  return Array.from(latestPerBarAndDay.values()).map(({ parsedDate, ...album }) => album);
+  // Sort albums newest first, then strip parsedDate before returning
+  const sortedAlbums = Array.from(latestPerBarAndDay.values()).sort((a, b) => b.parsedDate.getTime() - a.parsedDate.getTime());
+  return sortedAlbums.map(({ parsedDate, ...album }) => album);
 }
 
 /**
@@ -115,7 +116,7 @@ export async function getPhotosByAlbumUri(albumUri: string): Promise<Photo[]> {
  * Syntax: https://<DOMAIN>/cdn-cgi/image/<OPTIONS>/<IMAGE_PATH>
  */
 export function getResizedImageUri(originalUri: string, width: number = 400): string {
-  const USE_RESIZING = false; // toggle in case Cloudflare resizing doesn't work / is not available by build time
+  const USE_RESIZING = true; // toggle in case Cloudflare resizing doesn't work / is not available by build time
   if (!originalUri || !USE_RESIZING) return originalUri;
 
   try {
@@ -124,7 +125,7 @@ export function getResizedImageUri(originalUri: string, width: number = 400): st
       // Extracts the path after the domain
       const imagePath = urlObj.pathname;
       // quality=80 and format=auto will drastically reduce file size for grid photos
-      return `${IMAGE_DOMAIN}/cdn-cgi/image/width=${width},quality=80,format=auto${imagePath}`;
+      return `${IMAGE_DOMAIN}/cdn-cgi/image/width=${width},quality=80,format=auto,onerror=redirect${imagePath}`;
     }
   } catch (err) {
     // Ignore if invalid


### PR DESCRIPTION
Enabling resizing now that it's all working! 
Also adjusted all pages that use Cloudflare photos (gallery modals, album covers, album grids) to use resizing, leaving enlarged photos alone to preserve image quality for users to download. Image loading is a lot quicker and smoother now with this addition.

_Note_: Photos may lag the first time they are ever "seen" by someone on the app, as they take a couple of seconds to resize, but then they're cached, so every other time that image is "seen" it'll load almost instantly