### PR TITLE
Tonight page revamp

### DIFF
--- a/frontend/app/(app)/(tabs)/bars/[id].tsx
+++ b/frontend/app/(app)/(tabs)/bars/[id].tsx
@@ -4,19 +4,21 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 
 import { useBarDetail } from "@/hooks/useBarDetail";
 import { fetchLocationById, MapLocation } from "@/services/locationService";
-import { getNow, isActive, isBarOpen } from "@/utils/schedule";
+import { getNow, isBarOpen } from "@/utils/schedule";
+import type { TimeRule } from "@/types/types";
 import { Theme } from '@/constants/theme';
 import ErrorState from "@/components/ui/error-state";
 import { getLatestWeekAlbums, Album, getResizedImageUri } from "@/services/galleryService";
 
 import {
   BarHeader,
-  // BarStats, 
-  InfoSection,
+  // BarStats,
+  DealEventSection,
   BottomCard,
   BarMapModal,
   BarGalleryModal
 } from "@/components/bars/bar-detail-components";
+import type { DealOrEventItem } from "@/components/bars/deal-event-modal";
 import { getBarAssets } from "@/utils/bar-assets";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -175,8 +177,62 @@ export default function BarProfile() {
 
   const assets = getBarAssets(bar);
   const now = getNow();
-  const activeDeals = bar.dealsScheduled?.filter(d => isActive(d.rule, now)) ?? [];
-  const activeEvents = bar.eventsScheduled?.filter(e => isActive(e.rule, now)) ?? [];
+
+  // Returns true if this rule fires on today's date (regardless of whether it's active right now)
+  function isScheduledTonight(rule: TimeRule): boolean {
+    if (rule.kind === "one-time") {
+      const start = new Date(rule.start);
+      return (
+        start.getFullYear() === now.getFullYear() &&
+        start.getMonth() === now.getMonth() &&
+        start.getDate() === now.getDate()
+      );
+    }
+    // weekly: check if today's day-of-week is in the schedule
+    const todayDow = now.getDay();
+    return rule.daysOfWeek.includes(todayDow);
+  }
+
+  function ruleToStartTime(rule: TimeRule): string | undefined {
+    if (rule.kind === "one-time") {
+      return new Intl.DateTimeFormat("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      }).format(new Date(rule.start));
+    }
+    // weekly: parse startLocalTime "HH:MM" -> display string
+    const [hStr, mStr] = rule.startLocalTime.split(":");
+    const h = parseInt(hStr, 10);
+    const m = parseInt(mStr, 10);
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    return new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    }).format(d);
+  }
+
+  const tonightDeals: DealOrEventItem[] = (bar.dealsScheduled ?? [])
+    .filter(d => isScheduledTonight(d.rule))
+    .map(d => ({
+      id: d.id,
+      kind: "deal" as const,
+      title: d.title,
+      subtitle: d.subtitle,
+      startTime: ruleToStartTime(d.rule),
+    }));
+
+  const tonightEvents: DealOrEventItem[] = (bar.eventsScheduled ?? [])
+    .filter(e => isScheduledTonight(e.rule))
+    .map(e => ({
+      id: e.id,
+      kind: "event" as const,
+      title: e.name,
+      subtitle: e.description,
+      startTime: ruleToStartTime(e.rule),
+    }));
 
   const openNow = isBarOpen(
     {
@@ -216,8 +272,20 @@ export default function BarProfile() {
           <Text style={styles.menuButtonText}>View Menu</Text>
         </TouchableOpacity>
 
-        <InfoSection title="Current Events" items={activeEvents} emptyText="No active events." />
-        <InfoSection title="Deals" items={activeDeals} emptyText="No active deals." />
+        <DealEventSection
+          title="Events Tonight"
+          items={tonightEvents}
+          emptyText="No events scheduled tonight."
+          barName={bar.name}
+          barId={String(bar.id)}
+        />
+        <DealEventSection
+          title="Deals Tonight"
+          items={tonightDeals}
+          emptyText="No deals scheduled tonight."
+          barName={bar.name}
+          barId={String(bar.id)}
+        />
 
         <View style={styles.bottomRow}>
           <BottomCard

--- a/frontend/app/(app)/(tabs)/tonight.tsx
+++ b/frontend/app/(app)/(tabs)/tonight.tsx
@@ -262,12 +262,17 @@ function BarGroupedList({
   groups,
   query,
   onBarPress,
+  closeExpanded,
+  setExpandedBarId,
+  expandedBarId,
 }: {
   groups: BarGroupedTonight[];
   query: string;
   onBarPress: (id: string) => void;
+  closeExpanded: () => void;
+  setExpandedBarId: (id: string | null) => void;
+  expandedBarId: string | null;
 }) {
-  const [expandedBarId, setExpandedBarId] = React.useState<string | null>(null);
   const [selectedItem, setSelectedItem] = React.useState<BarDealOrEvent | null>(null);
   const [selectedBarId, setSelectedBarId] = React.useState<string>("");
   const [selectedBarName, setSelectedBarName] = React.useState<string>("");
@@ -327,13 +332,6 @@ function BarGroupedList({
 
   return (
     <View style={groupStyles.container}>
-      {/* Invisible backdrop — closes expanded card when tapping outside */}
-      {expandedBarId !== null && (
-        <Pressable
-          style={groupStyles.dropdownBackdrop}
-          onPress={() => setExpandedBarId(null)}
-        />
-      )}
       <TonightDetailModal
         item={selectedItem}
         barName={selectedBarName}
@@ -361,7 +359,7 @@ function BarGroupedList({
             key={group.barId}
             group={group}
             isExpanded={expandedBarId === group.barId}
-            onToggle={() => setExpandedBarId((curr) => (curr === group.barId ? null : group.barId))}
+            onToggle={() => setExpandedBarId(expandedBarId === group.barId ? null : group.barId)}
             onBarPress={onBarPress}
             onItemPress={(item) => openPopup(item, group.barId, group.barName)}
           />
@@ -414,7 +412,6 @@ const groupStyles = StyleSheet.create({
     borderWidth: 1,
     borderColor: Theme.container.secondaryBorder,
     backgroundColor: Theme.container.background,
-    overflow: "hidden",
   },
   cardShellExpanded: {
     borderColor: Theme.dark.primary,
@@ -669,6 +666,8 @@ export default function Tonight() {
   const [activeTab, setActiveTab] = useState<TabKey>("open");
   // Global search query (filters both bars and friends)
   const [query, setQuery] = useState("");
+  // Expanded bar in Tonight tab — lifted here so ScrollView can close it on drag
+  const [tonightExpandedBarId, setTonightExpandedBarId] = useState<string | null>(null);
 
   useEffect(() => {
     if (isTabKey(tab)) {
@@ -976,6 +975,9 @@ export default function Tonight() {
               groups={barGroupsTonight}
               query={query}
               onBarPress={(id) => goToBarDetail(id, "tonight-deals")}
+              expandedBarId={tonightExpandedBarId}
+              setExpandedBarId={setTonightExpandedBarId}
+              closeExpanded={() => setTonightExpandedBarId(null)}
             />
           )}
 

--- a/frontend/app/(app)/(tabs)/tonight.tsx
+++ b/frontend/app/(app)/(tabs)/tonight.tsx
@@ -14,6 +14,7 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  Modal,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from "react-native";
@@ -24,29 +25,27 @@ import { router, useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from '@react-navigation/native';
 
 import { useTonightData } from "@/hooks/useTonightData";
-// import { useFriends } from "@/hooks/useFriends";
+import type { BarGroupedTonight, BarDealOrEvent } from "@/hooks/useTonightData";
 import { useBars } from "@/hooks/useBars";
 
 import { shouldForceErrorPage } from "@/utils/dev-error-pages";
 import ErrorState from "@/components/ui/error-state";
 
 import { Theme } from "@/constants/theme";
+import { getLogoAssetForLocationName } from "@/utils/locationLogos";
 // import type { Friend } from "@/types/types";
 
 import OpenNowSection from "@/components/tonight/open-now-sections";
-import UpcomingSection from "@/components/tonight/upcomming-section";
 import FriendsSection from "@/components/tonight/friends-section";
-import DealsSection from "@/components/tonight/deals-section";
 import TonightHero from "@/components/tonight/hero-carousel";
 import { TonightSkeleton } from "@/components/tonight/tonight-skeleton";
 
-import { useUpcomingSchedule } from "@/hooks/use-upcoming-data";
 import { useTopHeaderVisibility } from '@/context/top-header-visibility';
 
 // Simple static metadata that drives the tab UI (key used in logic, label shown in UI)
 const TAB_META = [
   { key: "open", label: "Open Now" },
-  { key: "deals", label: "Deals Tonight" },
+  { key: "deals", label: "Tonight" },
   { key: "friends", label: "Friends Near You" },
 ] as const;
 
@@ -62,6 +61,597 @@ const BOTTOM_DEAD_ZONE_PX = 24;
 const HIDE_SCROLL_THRESHOLD_PX = 28;
 const SHOW_SCROLL_THRESHOLD_PX = 20;
 
+// ─── Tonight Tab ─────────────────────────────────────────────────────────────
+// Renders bars grouped by deals/events, matching the Friends Near You pattern.
+
+function formatTime(d?: Date): string {
+  if (!d) return "";
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(d);
+}
+
+function TonightPill({ kind }: { kind: "event" | "deal" }) {
+  const isEvent = kind === "event";
+  return (
+    <View style={[groupStyles.pill, { backgroundColor: isEvent ? Theme.dark.secondary : Theme.dark.primary }]}>
+      <Text style={groupStyles.pillText}>{isEvent ? "Event" : "Deal"}</Text>
+    </View>
+  );
+}
+
+// ─── Detail Popup ─────────────────────────────────────────────────────────────
+function TonightDetailModal({
+  item,
+  barName,
+  barId,
+  onClose,
+  onBarPress,
+}: {
+  item: BarDealOrEvent | null;
+  barName: string;
+  barId: string;
+  onClose: () => void;
+  onBarPress: (id: string) => void;
+}) {
+  return (
+    <Modal
+      visible={item !== null}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <Pressable style={groupStyles.modalBackdrop} onPress={onClose}>
+        <Pressable style={groupStyles.modalSheet} onPress={(e) => e.stopPropagation()}>
+          {/* Handle bar */}
+          <View style={groupStyles.modalHandle} />
+
+          {/* Logo + bar name */}
+          <View style={groupStyles.modalHeader}>
+            <Image
+              source={getLogoAssetForLocationName(barName)}
+              style={groupStyles.modalLogo}
+              resizeMode="cover"
+            />
+            <View style={{ flex: 1 }}>
+              <Text style={groupStyles.modalBarName}>{barName}</Text>
+              {item?.startTimeUtc ? (
+                <Text style={groupStyles.modalTime}>{formatTime(item.startTimeUtc)}</Text>
+              ) : null}
+            </View>
+            {item && <TonightPill kind={item.kind} />}
+          </View>
+
+          {/* Event/deal name */}
+          <Text style={groupStyles.modalTitle}>{item?.title}</Text>
+
+          {/* Description — only shown if one exists */}
+          {!!item?.subtitle && (
+            <Text style={groupStyles.modalDescription}>{item.subtitle}</Text>
+          )}
+
+          {/* Actions */}
+          <View style={groupStyles.modalActions}>
+            <Pressable
+              style={groupStyles.detailsButton}
+              onPress={() => { onClose(); onBarPress(barId); }}
+            >
+              <Text style={groupStyles.detailsButtonText}>View {barName} Details</Text>
+            </Pressable>
+            <Pressable style={groupStyles.closeButton} onPress={onClose}>
+              <Text style={groupStyles.closeButtonText}>Close</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+// ─── Bar Group Row ─────────────────────────────────────────────────────────────
+function BarGroupRow({
+  group,
+  isExpanded,
+  onToggle,
+  onBarPress,
+  onItemPress,
+}: {
+  group: BarGroupedTonight;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onBarPress: (id: string) => void;
+  onItemPress: (item: BarDealOrEvent) => void;
+}) {
+  const hasMore = group.rest.length > 0;
+
+  const sortedRest = React.useMemo(() =>
+    [...group.rest].sort((a, b) => {
+      const tA = a.startTimeUtc?.getTime() ?? Infinity;
+      const tB = b.startTimeUtc?.getTime() ?? Infinity;
+      return tA - tB;
+    }),
+  [group.rest]);
+
+  return (
+    <View style={[groupStyles.cardShell, isExpanded && groupStyles.cardShellExpanded]}>
+      {/* Main card row — split tap zones */}
+      <View style={groupStyles.card}>
+        {/* Logo — tapping opens bar detail */}
+        <Pressable onPress={() => onBarPress(group.barId)}>
+          <Image
+            source={getLogoAssetForLocationName(group.barName)}
+            style={groupStyles.cardImage}
+            resizeMode="cover"
+          />
+        </Pressable>
+
+        {/* Text — tapping opens popup */}
+        <Pressable style={{ flex: 1 }} onPress={() => onItemPress(group.highlight)}>
+          <Text style={groupStyles.cardTitle} numberOfLines={1}>
+            {group.highlight.title}
+          </Text>
+          {group.highlight.startTimeUtc ? (
+            <Text style={groupStyles.cardSubtitle}>{formatTime(group.highlight.startTimeUtc)}</Text>
+          ) : null}
+          <Text style={groupStyles.cardDetail}>{group.barName}</Text>
+        </Pressable>
+
+        {/* Right side — tapping toggles expand (or opens popup if no extras) */}
+        <Pressable
+          style={groupStyles.cardRight}
+          onPress={hasMore ? onToggle : () => onItemPress(group.highlight)}
+        >
+          <TonightPill kind={group.highlight.kind} />
+          {hasMore && (
+            <>
+              <Text style={groupStyles.moreText}>+{group.rest.length}</Text>
+              <Ionicons
+                name={isExpanded ? "chevron-up" : "chevron-down"}
+                size={18}
+                color={Theme.search.inactiveInput}
+              />
+            </>
+          )}
+        </Pressable>
+      </View>
+
+      {/* Expanded panel */}
+      {isExpanded && (
+        <View style={groupStyles.expandedPanel}>
+          <View style={groupStyles.panelHeader}>
+            <Text style={groupStyles.panelHeaderTitle}>Also Tonight</Text>
+            <Text style={groupStyles.panelHeaderCount}>{group.rest.length}</Text>
+          </View>
+          <View style={groupStyles.itemList}>
+            {sortedRest.map((item) => (
+              <Pressable
+                key={item.id}
+                style={groupStyles.itemRow}
+                onPress={() => onItemPress(item)}
+              >
+                <View style={{ flex: 1 }}>
+                  <Text style={groupStyles.itemTitle} numberOfLines={1}>{item.title}</Text>
+                  {item.startTimeUtc ? (
+                    <Text style={groupStyles.itemMeta}>{formatTime(item.startTimeUtc)}</Text>
+                  ) : null}
+                </View>
+                <TonightPill kind={item.kind} />
+                <Ionicons name="chevron-forward" size={16} color={Theme.search.inactiveInput} />
+              </Pressable>
+            ))}
+          </View>
+
+          {/* Action buttons */}
+          <View style={groupStyles.expandedActions}>
+            <Pressable style={groupStyles.detailsButton} onPress={() => onBarPress(group.barId)}>
+              <Text style={groupStyles.detailsButtonText}>View {group.barName} Details</Text>
+            </Pressable>
+            <Pressable style={groupStyles.closeButton} onPress={onToggle}>
+              <Text style={groupStyles.closeButtonText}>Collapse</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function BarGroupedList({
+  groups,
+  query,
+  onBarPress,
+}: {
+  groups: BarGroupedTonight[];
+  query: string;
+  onBarPress: (id: string) => void;
+}) {
+  const [expandedBarId, setExpandedBarId] = React.useState<string | null>(null);
+  const [selectedItem, setSelectedItem] = React.useState<BarDealOrEvent | null>(null);
+  const [selectedBarId, setSelectedBarId] = React.useState<string>("");
+  const [selectedBarName, setSelectedBarName] = React.useState<string>("");
+
+  const filtered = React.useMemo(() => {
+    const now = new Date();
+    const q = query.trim().toLowerCase();
+
+    let result = q
+      ? groups.filter(
+          (g) =>
+            g.barName.toLowerCase().includes(q) ||
+            g.highlight.title.toLowerCase().includes(q) ||
+            g.rest.some((r) => r.title.toLowerCase().includes(q))
+        )
+      : [...groups];
+
+    // Sort by highlight start time closest to now
+    result.sort((a, b) => {
+      const distA = a.highlight.startTimeUtc
+        ? Math.abs(a.highlight.startTimeUtc.getTime() - now.getTime())
+        : Infinity;
+      const distB = b.highlight.startTimeUtc
+        ? Math.abs(b.highlight.startTimeUtc.getTime() - now.getTime())
+        : Infinity;
+      return distA - distB;
+    });
+
+    return result;
+  }, [groups, query]);
+
+  const openPopup = (item: BarDealOrEvent, barId: string, barName: string) => {
+    setSelectedItem(item);
+    setSelectedBarId(barId);
+    setSelectedBarName(barName);
+  };
+
+  const closePopup = () => setSelectedItem(null);
+
+  if (filtered.length === 0) {
+    return (
+      <View style={groupStyles.stateContainer}>
+        <View style={groupStyles.iconCircle}>
+          <Ionicons name="pricetags-outline" size={40} color={Theme.dark.primary} />
+        </View>
+        <Text style={groupStyles.comingSoonHeader}>
+          {query.trim() ? "No matching deals or events" : "No deals or events tonight"}
+        </Text>
+        <Text style={groupStyles.emptyText}>
+          {query.trim()
+            ? "Try a different search term or clear the filter."
+            : "Check back later tonight for live deals and events."}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={groupStyles.container}>
+      {/* Invisible backdrop — closes expanded card when tapping outside */}
+      {expandedBarId !== null && (
+        <Pressable
+          style={groupStyles.dropdownBackdrop}
+          onPress={() => setExpandedBarId(null)}
+        />
+      )}
+      <TonightDetailModal
+        item={selectedItem}
+        barName={selectedBarName}
+        barId={selectedBarId}
+        onClose={closePopup}
+        onBarPress={onBarPress}
+      />
+
+      {/* Header row */}
+      <View style={groupStyles.headerRow}>
+        <View style={groupStyles.headerIcon}>
+          <Ionicons name="pricetag" size={18} color={Theme.dark.primary} />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text style={groupStyles.sectionTitle}>Tonight</Text>
+          <Text style={groupStyles.sectionSubtitle}>
+            {filtered.length} bar{filtered.length === 1 ? "" : "s"} with deals or events
+          </Text>
+        </View>
+      </View>
+
+      <View style={groupStyles.cardsList}>
+        {filtered.map((group) => (
+          <BarGroupRow
+            key={group.barId}
+            group={group}
+            isExpanded={expandedBarId === group.barId}
+            onToggle={() => setExpandedBarId((curr) => (curr === group.barId ? null : group.barId))}
+            onBarPress={onBarPress}
+            onItemPress={(item) => openPopup(item, group.barId, group.barName)}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const groupStyles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 92,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 14,
+  },
+  headerIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 12,
+    backgroundColor: Theme.search.background,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+  },
+  sectionTitle: {
+    color: Theme.container.titleText,
+    fontSize: 16,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 1.5,
+  },
+  sectionSubtitle: {
+    color: Theme.container.inactiveText,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  cardsList: {
+    gap: 12,
+    zIndex: 1,
+  },
+  cardShell: {
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+    backgroundColor: Theme.container.background,
+    overflow: "hidden",
+  },
+  cardShellExpanded: {
+    borderColor: Theme.dark.primary,
+  },
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    padding: 12,
+  },
+  cardImage: {
+    width: 48,
+    height: 48,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+  },
+  cardTitle: {
+    color: Theme.container.titleText,
+    fontWeight: "800",
+    fontSize: 14,
+  },
+  cardSubtitle: {
+    color: Theme.container.inactiveText,
+    marginTop: 2,
+    fontSize: 13,
+  },
+  cardDetail: {
+    color: Theme.container.inactiveText,
+    marginTop: 2,
+    fontSize: 12,
+  },
+  cardRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  moreText: {
+    color: Theme.container.inactiveText,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  pill: {
+    width: 52,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  pillText: {
+    color: "#0b0c12",
+    fontSize: 10,
+    fontWeight: "800",
+    textAlign: "center",
+  },
+  expandedPanel: {
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+    paddingTop: 4,
+    borderTopWidth: 1,
+    borderTopColor: Theme.container.secondaryBorder,
+    backgroundColor: "rgba(255,255,255,0.02)",
+  },
+  panelHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  panelHeaderTitle: {
+    color: Theme.container.titleText,
+    fontSize: 13,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 1.5,
+  },
+  panelHeaderCount: {
+    color: Theme.container.inactiveText,
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  itemList: {
+    gap: 10,
+  },
+  itemRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 4,
+  },
+  itemTitle: {
+    color: Theme.container.titleText,
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  itemMeta: {
+    color: Theme.container.inactiveText,
+    fontSize: 12,
+    marginTop: 1,
+  },
+  expandedActions: {
+    flexDirection: "row",
+    gap: 10,
+    marginTop: 12,
+    flexWrap: "wrap",
+  },
+  detailsButton: {
+    flex: 1,
+    backgroundColor: Theme.dark.primary,
+    paddingVertical: 10,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  detailsButtonText: {
+    color: Theme.dark.white,
+    fontWeight: "800",
+    fontSize: 13,
+  },
+  closeButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+    backgroundColor: Theme.search.background,
+  },
+  closeButtonText: {
+    color: Theme.container.titleText,
+    fontWeight: "700",
+    fontSize: 13,
+  },
+  stateContainer: {
+    paddingHorizontal: 16,
+    paddingTop: 28,
+    paddingBottom: 92,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconCircle: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    backgroundColor: Theme.search.background,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+  },
+  comingSoonHeader: {
+    color: Theme.container.titleText,
+    fontSize: 18,
+    fontWeight: "700",
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  emptyText: {
+    color: Theme.container.inactiveText,
+    textAlign: "center",
+    marginTop: 8,
+    fontSize: 13,
+  },
+  dropdownBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 0,
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 24,
+  },
+  modalSheet: {
+    backgroundColor: Theme.container.background,
+    borderRadius: 24,
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+    paddingTop: 20,
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+    width: "100%",
+  },
+  modalHandle: {
+    width: 0,
+    height: 0,
+    marginBottom: 0,
+  },
+  modalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 16,
+  },
+  modalLogo: {
+    width: 52,
+    height: 52,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+  },
+  modalBarName: {
+    color: Theme.container.titleText,
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  modalTime: {
+    color: Theme.container.inactiveText,
+    fontSize: 13,
+    marginTop: 2,
+  },
+  modalTitle: {
+    color: Theme.container.titleText,
+    fontSize: 20,
+    fontWeight: "800",
+    marginBottom: 10,
+  },
+  modalDescription: {
+    color: Theme.container.inactiveText,
+    fontSize: 14,
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  modalDescriptionEmpty: {
+    color: Theme.container.inactiveBorder,
+    fontSize: 14,
+    fontStyle: "italic",
+    marginBottom: 24,
+  },
+  modalActions: {
+    flexDirection: "row",
+    gap: 10,
+  },
+});
+
 export default function Tonight() {
 
   const insets = useSafeAreaInsets();
@@ -76,7 +666,7 @@ export default function Tonight() {
   const contentHeightRef = React.useRef(0);
 
   // Which tab the user is on
-  const [activeTab, setActiveTab] = useState<TabKey | null>(null);
+  const [activeTab, setActiveTab] = useState<TabKey>("open");
   // Global search query (filters both bars and friends)
   const [query, setQuery] = useState("");
 
@@ -161,7 +751,7 @@ export default function Tonight() {
   );
 
   // Fetch data from database using the custom hook
-  const { barsWithTonightData, allActiveDealsTonight, loading, error } = useTonightData();
+  const { barsWithTonightData, barGroupsTonight, loading, error } = useTonightData();
   const { bars: scheduledBars, loading: scheduledBarsLoading } = useBars();
 
   const friendsLoading = false;
@@ -170,18 +760,10 @@ export default function Tonight() {
   const hasError = !!error || !!friendsError || shouldForceErrorPage("tonight");
   const isLoading = loading || friendsLoading || scheduledBarsLoading;
 
-  // ----- Filter for active tab -----
-  // Take the computed list and filter based on the selected tab + text query.
+  // ----- Filter for "Open Now" tab -----
   const filteredBars = useMemo(() => {
     const q = query.trim().toLowerCase();
-    let data = barsWithTonightData;
-
-    // "Open Now" tab => only show bars that are currently open
-    if (activeTab === "open") data = data.filter((d) => d.isOpen);
-    // "Deals" tab => only bars with an active deal
-    if (activeTab === "deals") data = data.filter((d) => d.hasDeal);
-
-    // Text search across bar name, event name, and specials text
+    let data = barsWithTonightData.filter((d) => d.isOpen);
     if (q) {
       data = data.filter(
         (d) =>
@@ -191,61 +773,16 @@ export default function Tonight() {
       );
     }
     return data;
-  }, [activeTab, query, barsWithTonightData]);
-
-  // ----- Filter deals for "Deals Tonight" tab -----
-  const filteredDeals = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    let data = allActiveDealsTonight || [];
-
-    if (q) {
-      data = data.filter(
-        (d) =>
-          d.bar.toLowerCase().includes(q) ||
-          d.title.toLowerCase().includes(q) ||
-          (d.subtitle ?? "").toLowerCase().includes(q)
-      );
-    }
-    return data;
-  }, [query, allActiveDealsTonight]);
+  }, [query, barsWithTonightData]);
 
   const activeSummary = useMemo(() => {
-    if (activeTab === "open") {
-      const count = filteredBars.length;
-      return {
-        icon: "time-outline" as const,
-        title: "Open Now",
-        subtitle: `${count} bar${count === 1 ? "" : "s"} currently open`,
-      };
-    }
-
-    if (activeTab === "deals") {
-      const count = filteredDeals.length;
-      return {
-        icon: "pricetag-outline" as const,
-        title: "Deals Tonight",
-        subtitle: `${count} active deal${count === 1 ? "" : "s"} tonight`,
-      };
-    }
-
-    return null;
-  }, [activeTab, filteredBars.length, filteredDeals.length, query]);
-
-  const upcomingWeekData = useUpcomingSchedule(scheduledBars, query);
-
-  const homeSummary = useMemo(() => {
-    if (activeTab !== null) {
-      return null;
-    }
-
-    const count = upcomingWeekData.items.length;
-
+    const count = filteredBars.length;
     return {
-      icon: "calendar-outline" as const,
-      title: "Upcoming This Week",
-      subtitle: `${count} upcoming deal${count === 1 ? "" : "s"} and event${count === 1 ? "" : "s"}`,
+      icon: "time-outline" as const,
+      title: "Open Now",
+      subtitle: `${count} bar${count === 1 ? "" : "s"} currently open`,
     };
-  }, [activeTab, upcomingWeekData.items.length]);
+  }, [filteredBars.length]);
 
   // Navigation helpers
   // Use router.replace (not push) so no ghost entry is added to the native stack.
@@ -337,16 +874,14 @@ export default function Tonight() {
           {/* Sticky Tabs + Search (this whole block is sticky due to stickyHeaderIndices) */}
           <View style={styles.stickyTabs}>
 
-            {/* Tab row: renders from TAB_META and toggles activeTab */}
+            {/* Tab row: renders from TAB_META, always switches (no toggle off) */}
             <View style={styles.tabsRow}>
               {TAB_META.map((t) => {
                 const active = activeTab === t.key;
                 return (
                   <Pressable
                     key={t.key}
-                    onPress={() =>
-                      setActiveTab((prev) => (prev === t.key ? null : t.key))
-                    }
+                    onPress={() => setActiveTab(t.key)}
                     style={[styles.tabBtn, active && styles.tabBtnActive]}
                   >
                     <Text
@@ -387,55 +922,7 @@ export default function Tonight() {
             </View>
           </View>
 
-          {/* Content area switches between: 
-                "open now" 
-                "deals" 
-                "friends near you"
-                "active deals and events ('null')" 
-          */}
-          {/* Content area logic */}
-          {/* {activeTab === null && (
-            <>
-              <View style={styles.tabSummaryRow}>
-                <View style={styles.tabSummaryIcon}>
-                  <Ionicons name={homeSummary?.icon ?? "calendar-outline"} size={18} color={Theme.dark.primary} />
-                </View>
-                <View style={{ flex: 1 }}>
-                  <Text style={styles.tabSummaryTitle}>{homeSummary?.title}</Text>
-                  <Text style={styles.tabSummarySubtitle}>{homeSummary?.subtitle}</Text>
-                </View>
-              </View>
-              <UpcomingSection data={upcomingWeekData} onBarPress={goToBarDetail} />
-            </>
-          )} */}
-
-          {/* Content area logic for "Home" (no tab selected) */}
-          {activeTab === null && (
-            <>
-              {/* 1. Show the "Upcoming This Week" header only if there is matching data */}
-              {upcomingWeekData.items.length > 0 ? (
-                <View style={styles.tabSummaryRow}>
-                  <View style={styles.tabSummaryIcon}>
-                    <Ionicons
-                      name={homeSummary?.icon ?? "calendar-outline"}
-                      size={18}
-                      color={Theme.dark.primary}
-                    />
-                  </View>
-                  <View style={{ flex: 1 }}>
-                    <Text style={styles.tabSummaryTitle}>{homeSummary?.title}</Text>
-                    <Text style={styles.tabSummarySubtitle}>{homeSummary?.subtitle}</Text>
-                  </View>
-                </View>
-              ) : (
-                /* 2. Spacer to keep the "No matching" message aligned across all views */
-                <View style={{ height: 48 }} />
-              )}
-
-              {/* 3. The section itself handles the "No matching" UI internally */}
-              <UpcomingSection data={upcomingWeekData} onBarPress={goToBarDetail} />
-            </>
-          )}
+          {/* Content area switches between: open now | deals tonight | friends near you */}
 
           {/* {activeTab === "open" && (
             <View style={styles.tabSummaryRow}>
@@ -484,51 +971,12 @@ export default function Tonight() {
             </>
           )}
 
-          {/* {activeTab === "deals" && (
-            <View style={styles.tabSummaryRow}>
-              <View style={styles.tabSummaryIcon}>
-                <Ionicons name={activeSummary?.icon ?? "pricetag-outline"} size={18} color={Theme.dark.primary} />
-              </View>
-              <View style={{ flex: 1 }}>
-                <Text style={styles.tabSummaryTitle}>{activeSummary?.title}</Text>
-                <Text style={styles.tabSummarySubtitle}>{activeSummary?.subtitle}</Text>
-              </View>
-            </View>
-          )}
-
           {activeTab === "deals" && (
-            <DealsSection data={filteredDeals} onBarPress={(id) => goToBarDetail(id, "tonight-deals")} />
-          )} */}
-
-          {activeTab === "deals" && (
-            <>
-              {/* 1. Show the Summary Row if there's data, otherwise show the spacer */}
-              {filteredDeals.length > 0 ? (
-                <View style={styles.tabSummaryRow}>
-                  <View style={styles.tabSummaryIcon}>
-                    <Ionicons
-                      name={activeSummary?.icon ?? "pricetag-outline"}
-                      size={18}
-                      color={Theme.dark.primary}
-                    />
-                  </View>
-                  <View style={{ flex: 1 }}>
-                    <Text style={styles.tabSummaryTitle}>{activeSummary?.title}</Text>
-                    <Text style={styles.tabSummarySubtitle}>{activeSummary?.subtitle}</Text>
-                  </View>
-                </View>
-              ) : (
-                /* Spacer to match the Friends tab and maintain the message position */
-                <View style={{ height: 48 }} />
-              )}
-
-              {/* 2. Render the DealsSection below the header/spacer */}
-              <DealsSection
-                data={filteredDeals}
-                onBarPress={(id) => goToBarDetail(id, "tonight-deals")}
-                query={query}
-              />
-            </>
+            <BarGroupedList
+              groups={barGroupsTonight}
+              query={query}
+              onBarPress={(id) => goToBarDetail(id, "tonight-deals")}
+            />
           )}
 
           {activeTab === "friends" && (
@@ -620,7 +1068,8 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   tabBtnActive: {
-    borderColor: Theme.dark.primary, // "#38bdf8"
+    borderColor: Theme.dark.primary,
+    backgroundColor: Theme.dark.primary + "22", // subtle fill
   },
   tabText: {
     color: Theme.container.inactiveText, // "#cbd5e1",

--- a/frontend/app/(app)/(tabs)/tonight.tsx
+++ b/frontend/app/(app)/(tabs)/tonight.tsx
@@ -14,7 +14,6 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
-  Modal,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from "react-native";
@@ -41,6 +40,7 @@ import TonightHero from "@/components/tonight/hero-carousel";
 import { TonightSkeleton } from "@/components/tonight/tonight-skeleton";
 
 import { useTopHeaderVisibility } from '@/context/top-header-visibility';
+import { DealEventModal, DealEventPill } from "@/components/bars/deal-event-modal";
 
 // Simple static metadata that drives the tab UI (key used in logic, label shown in UI)
 const TAB_META = [
@@ -73,82 +73,8 @@ function formatTime(d?: Date): string {
   }).format(d);
 }
 
-function TonightPill({ kind }: { kind: "event" | "deal" }) {
-  const isEvent = kind === "event";
-  return (
-    <View style={[groupStyles.pill, { backgroundColor: isEvent ? Theme.dark.secondary : Theme.dark.primary }]}>
-      <Text style={groupStyles.pillText}>{isEvent ? "Event" : "Deal"}</Text>
-    </View>
-  );
-}
+// DealEventPill and DealEventModal live in @/components/bars/deal-event-modal
 
-// ─── Detail Popup ─────────────────────────────────────────────────────────────
-function TonightDetailModal({
-  item,
-  barName,
-  barId,
-  onClose,
-  onBarPress,
-}: {
-  item: BarDealOrEvent | null;
-  barName: string;
-  barId: string;
-  onClose: () => void;
-  onBarPress: (id: string) => void;
-}) {
-  return (
-    <Modal
-      visible={item !== null}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-    >
-      <Pressable style={groupStyles.modalBackdrop} onPress={onClose}>
-        <Pressable style={groupStyles.modalSheet} onPress={(e) => e.stopPropagation()}>
-          {/* Handle bar */}
-          <View style={groupStyles.modalHandle} />
-
-          {/* Logo + bar name */}
-          <View style={groupStyles.modalHeader}>
-            <Image
-              source={getLogoAssetForLocationName(barName)}
-              style={groupStyles.modalLogo}
-              resizeMode="cover"
-            />
-            <View style={{ flex: 1 }}>
-              <Text style={groupStyles.modalBarName}>{barName}</Text>
-              {item?.startTimeUtc ? (
-                <Text style={groupStyles.modalTime}>{formatTime(item.startTimeUtc)}</Text>
-              ) : null}
-            </View>
-            {item && <TonightPill kind={item.kind} />}
-          </View>
-
-          {/* Event/deal name */}
-          <Text style={groupStyles.modalTitle}>{item?.title}</Text>
-
-          {/* Description — only shown if one exists */}
-          {!!item?.subtitle && (
-            <Text style={groupStyles.modalDescription}>{item.subtitle}</Text>
-          )}
-
-          {/* Actions */}
-          <View style={groupStyles.modalActions}>
-            <Pressable
-              style={groupStyles.detailsButton}
-              onPress={() => { onClose(); onBarPress(barId); }}
-            >
-              <Text style={groupStyles.detailsButtonText}>View {barName} Details</Text>
-            </Pressable>
-            <Pressable style={groupStyles.closeButton} onPress={onClose}>
-              <Text style={groupStyles.closeButtonText}>Close</Text>
-            </Pressable>
-          </View>
-        </Pressable>
-      </Pressable>
-    </Modal>
-  );
-}
 
 // ─── Bar Group Row ─────────────────────────────────────────────────────────────
 function BarGroupRow({
@@ -203,7 +129,7 @@ function BarGroupRow({
           style={groupStyles.cardRight}
           onPress={hasMore ? onToggle : () => onItemPress(group.highlight)}
         >
-          <TonightPill kind={group.highlight.kind} />
+          <DealEventPill kind={group.highlight.kind} />
           {hasMore && (
             <>
               <Text style={groupStyles.moreText}>+{group.rest.length}</Text>
@@ -237,7 +163,7 @@ function BarGroupRow({
                     <Text style={groupStyles.itemMeta}>{formatTime(item.startTimeUtc)}</Text>
                   ) : null}
                 </View>
-                <TonightPill kind={item.kind} />
+                <DealEventPill kind={item.kind} />
                 <Ionicons name="chevron-forward" size={16} color={Theme.search.inactiveInput} />
               </Pressable>
             ))}
@@ -332,8 +258,8 @@ function BarGroupedList({
 
   return (
     <View style={groupStyles.container}>
-      <TonightDetailModal
-        item={selectedItem}
+      <DealEventModal
+        item={selectedItem ? { id: selectedItem.id, kind: selectedItem.kind, title: selectedItem.title, subtitle: selectedItem.subtitle, startTime: selectedItem.startTimeUtc ? new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit", hour12: true }).format(selectedItem.startTimeUtc) : undefined } : null}
         barName={selectedBarName}
         barId={selectedBarId}
         onClose={closePopup}
@@ -412,6 +338,7 @@ const groupStyles = StyleSheet.create({
     borderWidth: 1,
     borderColor: Theme.container.secondaryBorder,
     backgroundColor: Theme.container.background,
+    overflow: "hidden",
   },
   cardShellExpanded: {
     borderColor: Theme.dark.primary,
@@ -453,19 +380,6 @@ const groupStyles = StyleSheet.create({
     color: Theme.container.inactiveText,
     fontSize: 12,
     fontWeight: "600",
-  },
-  pill: {
-    width: 52,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingVertical: 4,
-    borderRadius: 999,
-  },
-  pillText: {
-    color: "#0b0c12",
-    fontSize: 10,
-    fontWeight: "800",
-    textAlign: "center",
   },
   expandedPanel: {
     paddingHorizontal: 12,
@@ -579,73 +493,6 @@ const groupStyles = StyleSheet.create({
   dropdownBackdrop: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 0,
-  },
-  modalBackdrop: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.6)",
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 24,
-  },
-  modalSheet: {
-    backgroundColor: Theme.container.background,
-    borderRadius: 24,
-    paddingHorizontal: 20,
-    paddingBottom: 24,
-    paddingTop: 20,
-    borderWidth: 1,
-    borderColor: Theme.container.secondaryBorder,
-    width: "100%",
-  },
-  modalHandle: {
-    width: 0,
-    height: 0,
-    marginBottom: 0,
-  },
-  modalHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    marginBottom: 16,
-  },
-  modalLogo: {
-    width: 52,
-    height: 52,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: Theme.container.secondaryBorder,
-  },
-  modalBarName: {
-    color: Theme.container.titleText,
-    fontSize: 14,
-    fontWeight: "700",
-  },
-  modalTime: {
-    color: Theme.container.inactiveText,
-    fontSize: 13,
-    marginTop: 2,
-  },
-  modalTitle: {
-    color: Theme.container.titleText,
-    fontSize: 20,
-    fontWeight: "800",
-    marginBottom: 10,
-  },
-  modalDescription: {
-    color: Theme.container.inactiveText,
-    fontSize: 14,
-    lineHeight: 22,
-    marginBottom: 24,
-  },
-  modalDescriptionEmpty: {
-    color: Theme.container.inactiveBorder,
-    fontSize: 14,
-    fontStyle: "italic",
-    marginBottom: 24,
-  },
-  modalActions: {
-    flexDirection: "row",
-    gap: 10,
   },
 });
 
@@ -829,6 +676,8 @@ export default function Tonight() {
             const clampedY = Math.max(0, Math.min(y, maxY));
             lastScrollYRef.current = clampedY;
             dragStartYRef.current = clampedY;
+            // Close any expanded dropdown when user starts scrolling
+            if (tonightExpandedBarId !== null) setTonightExpandedBarId(null);
           }}
           onScrollEndDrag={(event) => {
             const velocityY = event.nativeEvent.velocity?.y ?? 0;

--- a/frontend/components/bars/bar-detail-components.tsx
+++ b/frontend/components/bars/bar-detail-components.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
-import { View, Text, Image, TouchableOpacity, TouchableWithoutFeedback, StyleSheet, Dimensions, } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Image, TouchableOpacity, TouchableWithoutFeedback, StyleSheet, Dimensions, Pressable } from 'react-native';
 import { FontAwesome } from "@expo/vector-icons";
+import { Ionicons } from "@expo/vector-icons";
+import { DealEventModal, DealEventPill } from "@/components/bars/deal-event-modal";
+import type { DealOrEventItem } from "@/components/bars/deal-event-modal";
+import type { ScheduledDeal, ScheduledEvent } from "@/types/bars";
 import { Theme } from '@/constants/theme';
 import { Bar } from '@/utils/bar-assets';
 
@@ -168,18 +172,56 @@ export const BarHeader = ({ bar, assets, openNow, statusText }: BarHeaderProps) 
   </View>
 );
 
-export const InfoSection = ({ title, items, emptyText }: { title: string, items: any[], emptyText: string }) => (
-  <View style={styles.sectionContainer}>
-    <Text style={styles.sectionTitle}>{title}</Text>
-    {items.length ? (
-      items.map((item, i) => (
-        <Text key={i} style={styles.sectionItem}>• {item.name || item.title}</Text>
-      ))
-    ) : (
-      <Text style={styles.sectionItem}>{emptyText}</Text>
-    )}
-  </View>
-);
+export const DealEventSection = ({
+  title,
+  items,
+  emptyText,
+  barName,
+  barId,
+}: {
+  title: string;
+  items: DealOrEventItem[];
+  emptyText: string;
+  barName: string;
+  barId: string;
+}) => {
+  const [selectedItem, setSelectedItem] = useState<DealOrEventItem | null>(null);
+
+  return (
+    <View style={styles.sectionContainer}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+
+      {items.length === 0 ? (
+        <Text style={styles.sectionEmpty}>{emptyText}</Text>
+      ) : (
+        items.map((item) => (
+          <Pressable
+            key={item.id}
+            style={({ pressed }) => [styles.dealCard, pressed && { opacity: 0.75 }]}
+            onPress={() => setSelectedItem(item)}
+          >
+            <View style={{ flex: 1 }}>
+              <Text style={styles.dealTitle} numberOfLines={1}>{item.title}</Text>
+              {item.startTime ? (
+                <Text style={styles.dealTime}>{item.startTime}</Text>
+              ) : null}
+            </View>
+            <DealEventPill kind={item.kind} />
+            <Ionicons name="chevron-forward" size={16} color="#6B7280" />
+          </Pressable>
+        ))
+      )}
+
+      <DealEventModal
+        item={selectedItem}
+        barName={barName}
+        barId={barId}
+        onClose={() => setSelectedItem(null)}
+        // No onBarPress — already on the bar page
+      />
+    </View>
+  );
+};
 
 export const BottomCard = ({ title, image, onPress }: { title: string, image: any, onPress: () => void }) => (
   <TouchableOpacity style={styles.bottomCard} onPress={onPress}>
@@ -398,5 +440,30 @@ const styles = StyleSheet.create({
     fontSize: 14,
     opacity: 0.8,
     marginBottom: 15,
+  },
+  sectionEmpty: {
+    color: Theme.container.inactiveText,
+    fontSize: 14,
+    fontStyle: "italic",
+    marginTop: 2,
+  },
+  dealCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 2,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255,255,255,0.06)",
+  },
+  dealTitle: {
+    color: Theme.container.titleText,
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  dealTime: {
+    color: Theme.container.inactiveText,
+    fontSize: 12,
+    marginTop: 2,
   },
 });

--- a/frontend/components/bars/deal-event-modal.tsx
+++ b/frontend/components/bars/deal-event-modal.tsx
@@ -98,10 +98,8 @@ export function DealEventModal({
           <Text style={modalStyles.title}>{item?.title}</Text>
 
           {/* Description */}
-          {item?.subtitle ? (
-            <Text style={modalStyles.description}>{item.subtitle}</Text>
-          ) : (
-            <Text style={modalStyles.descriptionEmpty}>No description available.</Text>
+          {!!item?.subtitle && (
+            <Text style={[modalStyles.description, { marginBottom: 24 }]}>{item.subtitle}</Text>
           )}
 
           {/* Actions */}
@@ -180,13 +178,6 @@ const modalStyles = StyleSheet.create({
     color: Theme.container.inactiveText,
     fontSize: 14,
     lineHeight: 22,
-    marginBottom: 24,
-  },
-  descriptionEmpty: {
-    color: Theme.container.inactiveBorder,
-    fontSize: 14,
-    fontStyle: "italic",
-    marginBottom: 24,
   },
   actions: {
     flexDirection: "row",

--- a/frontend/components/bars/deal-event-modal.tsx
+++ b/frontend/components/bars/deal-event-modal.tsx
@@ -1,0 +1,222 @@
+// components/bars/deal-event-modal.tsx
+// Shared modal + pill for deal/event detail popups.
+// Used by both the Tonight tab and the Bar detail page.
+
+import React from "react";
+import { View, Text, Image, Pressable, Modal, StyleSheet } from "react-native";
+import { Theme } from "@/constants/theme";
+import { getLogoAssetForLocationName } from "@/utils/locationLogos";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DealOrEventItem = {
+  id: string;
+  kind: "deal" | "event";
+  title: string;
+  /** Optional description / subtitle shown in the modal body */
+  subtitle?: string;
+  /** Optional start time for display */
+  startTime?: string; // display string e.g. "9:00 PM"
+};
+
+// ─── Pill ─────────────────────────────────────────────────────────────────────
+
+export function DealEventPill({ kind }: { kind: "event" | "deal" }) {
+  const isEvent = kind === "event";
+  return (
+    <View
+      style={[
+        pillStyles.pill,
+        { backgroundColor: isEvent ? Theme.dark.secondary : Theme.dark.primary },
+      ]}
+    >
+      <Text style={pillStyles.pillText}>{isEvent ? "Event" : "Deal"}</Text>
+    </View>
+  );
+}
+
+const pillStyles = StyleSheet.create({
+  pill: {
+    width: 52,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  pillText: {
+    color: "#0b0c12",
+    fontSize: 10,
+    fontWeight: "800",
+    textAlign: "center",
+  },
+});
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+interface DealEventModalProps {
+  item: DealOrEventItem | null;
+  barName: string;
+  barId: string;
+  onClose: () => void;
+  /** Optional — if omitted the "View Details" button is hidden (e.g. already on bar page) */
+  onBarPress?: (id: string) => void;
+}
+
+export function DealEventModal({
+  item,
+  barName,
+  barId,
+  onClose,
+  onBarPress,
+}: DealEventModalProps) {
+  return (
+    <Modal
+      visible={item !== null}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <Pressable style={modalStyles.backdrop} onPress={onClose}>
+        <Pressable style={modalStyles.sheet} onPress={(e) => e.stopPropagation()}>
+          {/* Logo + bar name row */}
+          <View style={modalStyles.header}>
+            <Image
+              source={getLogoAssetForLocationName(barName)}
+              style={modalStyles.logo}
+              resizeMode="cover"
+            />
+            <View style={{ flex: 1 }}>
+              <Text style={modalStyles.barName}>{barName}</Text>
+              {item?.startTime ? (
+                <Text style={modalStyles.time}>{item.startTime}</Text>
+              ) : null}
+            </View>
+            {item && <DealEventPill kind={item.kind} />}
+          </View>
+
+          {/* Title */}
+          <Text style={modalStyles.title}>{item?.title}</Text>
+
+          {/* Description */}
+          {item?.subtitle ? (
+            <Text style={modalStyles.description}>{item.subtitle}</Text>
+          ) : (
+            <Text style={modalStyles.descriptionEmpty}>No description available.</Text>
+          )}
+
+          {/* Actions */}
+          <View style={modalStyles.actions}>
+            {onBarPress && (
+              <Pressable
+                style={modalStyles.detailsButton}
+                onPress={() => {
+                  onClose();
+                  onBarPress(barId);
+                }}
+              >
+                <Text style={modalStyles.detailsButtonText}>
+                  View {barName} Details
+                </Text>
+              </Pressable>
+            )}
+            <Pressable style={modalStyles.closeButton} onPress={onClose}>
+              <Text style={modalStyles.closeButtonText}>Close</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const modalStyles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 24,
+  },
+  sheet: {
+    backgroundColor: Theme.container.background,
+    borderRadius: 24,
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+    paddingTop: 20,
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+    width: "100%",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 16,
+  },
+  logo: {
+    width: 52,
+    height: 52,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+  },
+  barName: {
+    color: Theme.container.titleText,
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  time: {
+    color: Theme.container.inactiveText,
+    fontSize: 13,
+    marginTop: 2,
+  },
+  title: {
+    color: Theme.container.titleText,
+    fontSize: 20,
+    fontWeight: "800",
+    marginBottom: 10,
+  },
+  description: {
+    color: Theme.container.inactiveText,
+    fontSize: 14,
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  descriptionEmpty: {
+    color: Theme.container.inactiveBorder,
+    fontSize: 14,
+    fontStyle: "italic",
+    marginBottom: 24,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  detailsButton: {
+    flex: 1,
+    backgroundColor: Theme.dark.primary,
+    paddingVertical: 10,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  detailsButtonText: {
+    color: Theme.dark.white,
+    fontWeight: "800",
+    fontSize: 13,
+  },
+  closeButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: Theme.container.secondaryBorder,
+    backgroundColor: Theme.search.background,
+  },
+  closeButtonText: {
+    color: Theme.container.titleText,
+    fontWeight: "700",
+    fontSize: 13,
+  },
+});

--- a/frontend/hooks/useDeals.ts
+++ b/frontend/hooks/useDeals.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { getActiveDeals, Deal } from "@/services/dealsService";
+// TODO: Swap back to getActiveDeals when dedicated tonight API is ready
+import { getDeals, Deal } from "@/services/dealsService";
 
 export function useDeals() {
   const [deals, setDeals] = useState<Deal[]>([]);
@@ -10,7 +11,8 @@ export function useDeals() {
     const fetchDeals = async () => {
       try {
         setLoading(true);
-        const data = await getActiveDeals();
+        // TODO: Replace getDeals() with getActiveDeals() (or getTonightDeals()) when API is ready
+        const data = await getDeals();
         setDeals(data);
         setError(null);
       } catch (err) {

--- a/frontend/hooks/useEvents.ts
+++ b/frontend/hooks/useEvents.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
-import { getActiveEvents, Event } from "@/services/eventsService";
+// TODO: Swap back to getActiveEvents when dedicated tonight API is ready
+import { getEvents, Event } from "@/services/eventsService";
 
 export function useEvents() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -9,7 +10,8 @@ export function useEvents() {
   const fetchEvents = useCallback(async () => {
     try {
       setLoading(true);
-      const data = await getActiveEvents();
+      // TODO: Replace getEvents() with getActiveEvents() (or getTonightEvents()) when API is ready
+      const data = await getEvents();
       setEvents(data);
       setError(null);
     } catch (err) {

--- a/frontend/hooks/useTonightData.ts
+++ b/frontend/hooks/useTonightData.ts
@@ -1,6 +1,14 @@
 import { useMemo } from "react";
 import { useDeals } from "./useDeals";
 import { useEvents } from "./useEvents";
+
+// ─── TODO: API SWAP POINT ────────────────────────────────────────────────────
+// When the "deals and events happening today" endpoint is ready, replace:
+//   useDeals()  →  useTonightDeals()   (hits /api/deals/today or similar)
+//   useEvents() →  useTonightEvents()  (hits /api/events/today or similar)
+// The hooks should return the same { deals, events, loading, error } shape.
+// Remove filterTonightOccurrences() below once the API does the filtering.
+// ─────────────────────────────────────────────────────────────────────────────
 import { useOpenBars } from "./useOpenBars";
 import { Deal } from "@/services/dealsService";
 import { Event } from "@/services/eventsService";
@@ -28,11 +36,28 @@ export interface TonightDealData {
   isActiveNow: boolean;
 }
 
+export interface BarDealOrEvent {
+  id: string;
+  kind: 'event' | 'deal';
+  title: string;
+  subtitle?: string;
+  startTimeUtc?: Date;
+}
+
+export interface BarGroupedTonight {
+  barId: string;
+  barName: string;
+  logoUrl?: string;
+  highlight: BarDealOrEvent;
+  rest: BarDealOrEvent[];
+}
+
 interface NormalizedActiveDeal {
   dealId: string;
   locationId: string;
   title: string;
   subtitle?: string;
+  startTimeUtc?: Date;
 }
 
 interface NormalizedActiveEvent {
@@ -40,6 +65,7 @@ interface NormalizedActiveEvent {
   locationId: string;
   name: string;
   description?: string;
+  startTimeUtc?: Date;
 }
 
 interface LocationHourRow {
@@ -184,6 +210,61 @@ function getOpenHoursText(location: Location): string | undefined {
   return getHoursFromSchedule(location);
 }
 
+// ─── Tonight Filter ──────────────────────────────────────────────────────────
+// TODO: Remove this function once the backend has a dedicated "today" endpoint.
+// Keeps only deals/events that have at least one occurrence starting or active
+// on the current calendar day in America/Chicago (CDT/CST).
+function filterTonightOccurrences<T extends {
+  deal_occurrences?: Array<{ start_time_utc: string | Date; end_time_utc: string | Date }>;
+  event_occurrences?: Array<{ start_time_utc: string | Date; end_time_utc: string | Date }>;
+}>(items: T[]): T[] {
+  const now = new Date();
+
+  // Get today's date string in CDT (America/Chicago)
+  const todayStr = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Chicago",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+
+  // Also include yesterday's date to catch overnight deals (e.g. started 10PM, ends 2AM)
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Chicago",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(yesterday);
+
+  const isTonight = (occurrences: Array<{ start_time_utc: string | Date; end_time_utc: string | Date }>) => {
+    return occurrences.some((occ) => {
+      const start = new Date(occ.start_time_utc);
+      const end = new Date(occ.end_time_utc);
+
+      // Must not have already ended
+      if (end < now) return false;
+
+      // Start must be today or yesterday (overnight) in CDT
+      const startStr = new Intl.DateTimeFormat("en-US", {
+        timeZone: "America/Chicago",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(start);
+
+      return startStr === todayStr || startStr === yesterdayStr;
+    });
+  };
+
+  return items.filter((item) => {
+    const occurrences = item.deal_occurrences ?? item.event_occurrences ?? [];
+    return isTonight(occurrences);
+  });
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 function normalizeActiveDeal(deal: Deal): NormalizedActiveDeal | null {
   const rawDeal = deal as Deal & {
     id?: string | number;
@@ -191,6 +272,8 @@ function normalizeActiveDeal(deal: Deal): NormalizedActiveDeal | null {
     title?: string;
     name?: string;
     description?: string;
+    start_time_utc?: string | Date;
+    deal_occurrences?: Array<{ start_time_utc: string | Date; end_time_utc: string | Date }>;
     deals?: {
       id?: string | number;
       location_id?: string | number;
@@ -208,13 +291,17 @@ function normalizeActiveDeal(deal: Deal): NormalizedActiveDeal | null {
   const dealId = String(rawDeal.id ?? rawDeal.deals?.id ?? "");
   const title = rawDeal.title ?? rawDeal.name ?? rawDeal.deals?.title ?? rawDeal.deals?.name ?? "Deal";
   const subtitle = rawDeal.description ?? rawDeal.deals?.description;
-  const normalizedDeal: NormalizedActiveDeal = {
-    dealId,
-    locationId,
-    title,
-  };
 
+  // Try top-level start_time_utc first (active endpoint), then first nested occurrence (all endpoint)
+  const startTimeUtc = rawDeal.start_time_utc
+    ? new Date(rawDeal.start_time_utc)
+    : rawDeal.deal_occurrences?.[0]?.start_time_utc
+      ? new Date(rawDeal.deal_occurrences[0].start_time_utc)
+      : undefined;
+
+  const normalizedDeal: NormalizedActiveDeal = { dealId, locationId, title };
   if (subtitle) normalizedDeal.subtitle = subtitle;
+  if (startTimeUtc) normalizedDeal.startTimeUtc = startTimeUtc;
 
   return normalizedDeal;
 }
@@ -225,6 +312,8 @@ function normalizeActiveEvent(event: Event): NormalizedActiveEvent | null {
     location_id?: string | number;
     name?: string;
     description?: string;
+    start_time_utc?: string | Date;
+    event_occurrences?: Array<{ start_time_utc: string | Date; end_time_utc: string | Date }>;
     events?: {
       id?: string | number;
       location_id?: string | number;
@@ -247,13 +336,16 @@ function normalizeActiveEvent(event: Event): NormalizedActiveEvent | null {
     "Event";
   const description = rawEvent.description ?? rawEvent.events?.description;
 
-  const normalizedEvent: NormalizedActiveEvent = {
-    eventId,
-    locationId,
-    name,
-  };
+  // Try top-level start_time_utc first (active endpoint), then first nested occurrence (all endpoint)
+  const startTimeUtc = rawEvent.start_time_utc
+    ? new Date(rawEvent.start_time_utc)
+    : rawEvent.event_occurrences?.[0]?.start_time_utc
+      ? new Date(rawEvent.event_occurrences[0].start_time_utc)
+      : undefined;
 
+  const normalizedEvent: NormalizedActiveEvent = { eventId, locationId, name };
   if (description) normalizedEvent.description = description;
+  if (startTimeUtc) normalizedEvent.startTimeUtc = startTimeUtc;
 
   return normalizedEvent;
 }
@@ -267,13 +359,15 @@ export function useTonightData() {
   const error = dealsError || eventsError || barsError;
 
   const activeDeals = useMemo(() => {
-    return deals
+    // TODO: When API swap is done, remove filterTonightOccurrences() call here
+    return filterTonightOccurrences(deals)
       .map((deal) => normalizeActiveDeal(deal))
       .filter((deal): deal is NormalizedActiveDeal => Boolean(deal));
   }, [deals]);
 
   const activeEvents = useMemo(() => {
-    return events
+    // TODO: When API swap is done, remove filterTonightOccurrences() call here
+    return filterTonightOccurrences(events)
       .map((event) => normalizeActiveEvent(event))
       .filter((event): event is NormalizedActiveEvent => Boolean(event));
   }, [events]);
@@ -359,9 +453,70 @@ export function useTonightData() {
       .filter((item): item is TonightDealData => Boolean(item));
   }, [bars, activeDeals]);
 
+  // Build grouped bar view for "Deals Tonight" tab
+  // Each bar gets one highlighted item (event preferred, then deal) and the rest collapsed
+  const barGroupsTonight = useMemo((): BarGroupedTonight[] => {
+    const now = new Date();
+    const openLocationIds = new Set(bars.map((b) => String(b.id)));
+
+    // Helper: distance from now in ms (for sorting by proximity)
+    const distFromNow = (d?: Date) =>
+      d ? Math.abs(d.getTime() - now.getTime()) : Infinity;
+
+    const groups: BarGroupedTonight[] = [];
+
+    bars.forEach((location) => {
+      const locationId = String(location.id);
+      if (!openLocationIds.has(locationId)) return;
+
+      // Collect all events for this bar
+      const barEvents: BarDealOrEvent[] = activeEvents
+        .filter((e) => e.locationId === locationId)
+        .map((e) => ({
+          id: `event-${e.eventId}`,
+          kind: 'event' as const,
+          title: e.name,
+          subtitle: e.description,
+          startTimeUtc: e.startTimeUtc,
+        }))
+        .sort((a, b) => distFromNow(a.startTimeUtc) - distFromNow(b.startTimeUtc));
+
+      // Collect all deals for this bar
+      const barDeals: BarDealOrEvent[] = activeDeals
+        .filter((d) => d.locationId === locationId)
+        .map((d) => ({
+          id: `deal-${d.dealId}`,
+          kind: 'deal' as const,
+          title: d.title,
+          subtitle: d.subtitle,
+          startTimeUtc: d.startTimeUtc,
+        }))
+        .sort((a, b) => distFromNow(a.startTimeUtc) - distFromNow(b.startTimeUtc));
+
+      const all = [...barEvents, ...barDeals];
+      if (all.length === 0) return; // exclude bars with nothing tonight
+
+      // Highlight: first event (closest to now), or first deal if no events
+      const highlight = all[0];
+      const rest = all.slice(1);
+
+      groups.push({
+        barId: locationId,
+        barName: location.name,
+        logoUrl: location.logoUrl,
+        highlight,
+        rest,
+      });
+    });
+
+    // Sort bars alphabetically
+    return groups.sort((a, b) => a.barName.localeCompare(b.barName));
+  }, [bars, activeEvents, activeDeals]);
+
   return {
     barsWithTonightData,
     allActiveDealsTonight,
+    barGroupsTonight,
     loading,
     error,
   };


### PR DESCRIPTION
# Tonight Tab Redesign
 
- Default tab changed to **Open Now**, "Upcoming This Week" removed
- Tabs no longer toggle off when re-tapped
- "Deals Tonight" renamed to **"Tonight"** now groups deals and events by bar, one card per bar
- Each card shows the best highlight (event preferred, then deal, both by closest start time), with a dropdown for additional items
- Tapping an event/deal name opens a detail popup; tapping the logo navigates to the bar
- `useDeals` and `useEvents` fetch all records and filter client-side to tonight's occurrences until a dedicated API endpoint is ready
- popup for event added to bar page along with updated formatting for events and deals
 